### PR TITLE
Hotfix - Tagging default bump

### DIFF
--- a/.github/workflows/tag-main.yml
+++ b/.github/workflows/tag-main.yml
@@ -5,11 +5,12 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: '0'
-    - name: Increase version and push tag
-      uses: anothrNick/github-tag-action@1.36.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: Increase version and push tag
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch


### PR DESCRIPTION
Bump was defaulting to minor when it should be patch