### PR TITLE
Potential workaround for production Bicep deploy issue

### DIFF
--- a/.github/workflows/deploy-azure-function.yml
+++ b/.github/workflows/deploy-azure-function.yml
@@ -45,7 +45,9 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
         uses: azure/CLI@v1
         with:
+          # 1st command is a workaround for https://github.com/Azure/azure-cli/issues/25710
           inlineScript: |
+            az config set bicep.use_binary_from_path=false
             az deployment group create -f ${{ inputs.bicep-file }} -g ${{ inputs.resource-group }} -n "${{ inputs.functionapp-name }}-security-rules" -p functionAppName=${{ inputs.functionapp-name }} ipAddress=${{ steps.ip.outputs.ipv4 }}
 
       # Download build artifact


### PR DESCRIPTION
## Issue Type

<!-- ignore-task-list-start -->

- [x] 🪲 Fix
- [ ] 💡 Improvement
- [ ] 🏁 Feature
- [ ] 🍾 Release
<!-- ignore-task-list-end -->

## Description

Production deploy started failing since few days, for example: https://github.com/SmarterTechnologies/SmarterTechnologies.Water.ProvisioningAPI/actions/runs/4471024209

![image](https://user-images.githubusercontent.com/88328563/226562247-58f440ed-675a-4c65-bc36-0e23a79ea8f7.png)

The issue started appearing with `azure-cli:2.46.0` which is used by `azure/CLI@v1`.
Long story: https://github.com/Azure/azure-cli/issues/25710
I did essentially this: https://github.com/johnnyreilly/blog.johnnyreilly.com/pull/476/files (guy also mentioned the above PR and lot of ppl mentioned that changing `use_binary_from_path` helped them.

## Checklist

- [ ] I am merging into the correct branch
- [ ] I have tested that my fix/feature works and meets the acceptance criteria
- [ ] I have added IDs for automation purposes and informed testing team
- [ ] I have updated the configuration with changes (API)
- [ ] I have updated the user documentation (GUI)
