### PR TITLE
[Hotfix] GTP-1139 Fixed azcliversion to avoid breaking changes to bicep in latest version

### DIFF
--- a/.github/workflows/deploy-azure-function.yml
+++ b/.github/workflows/deploy-azure-function.yml
@@ -45,6 +45,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
         uses: azure/CLI@v1
         with:
+          azcliversion: 2.63.0 # 2.64 Has breaking changes https://github.com/Azure/cli/issues/165 https://github.com/Azure/azure-cli/issues/29828
           # 1st command is a workaround for https://github.com/Azure/azure-cli/issues/25710
           inlineScript: |
             az config set bicep.use_binary_from_path=false


### PR DESCRIPTION
## Issue Type

<!-- ignore-task-list-start -->

- [X] 🪲 Fix
- [ ] 💡 Improvement
- [ ] 🏁 Feature
- [ ] 🍾 Release
<!-- ignore-task-list-end -->

## Description

- Set azcliversion to 2.63 as 2.64 has breaking changes to bicep

## Checklist

- [X] I am merging into the correct branch
- [X] I have tested that my fix/feature works and meets the acceptance criteria
