### PR TITLE
GTP-1565 Mitigating set-output becoming deprecated

### DIFF
--- a/.github/workflows/create-slot-name.yml
+++ b/.github/workflows/create-slot-name.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Get branch name
         if: ${{ inputs.branch-name == '' }}
         id: auto-branch-name
-        uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2
+        uses: tj-actions/branch-names@v8
 
       # Remove forward slash from name as its invalid for deployment slot name.
       # Uses v2      
-      - name: Remove feature from branch name
+      - name: Remove '/' from branch name
         id: rename-branch-name
-        uses: mad9000/actions-find-and-replace-string@27ff719b52870980e6ce19c288c5d3cc3ad202fa
+        uses: mad9000/actions-find-and-replace-string@5
         with:
           source: ${{ inputs.branch-name || steps.auto-branch-name.outputs.current_branch }}
           find: '/'
@@ -52,7 +52,7 @@ jobs:
         # Uses v1.2.0
       - name: Truncate branch name
         id: truncate-branch-name
-        uses: 2428392/gh-truncate-string-action@51c56c4b37c0f79b5f662782e22cddc712ba45b8
+        uses: 2428392/gh-truncate-string-action@v1.4
         with:
           stringToTruncate: ${{ steps.rename-branch-name.outputs.value }}
           maxLength: ${{ env.max-length }}

--- a/.github/workflows/create-slot-name.yml
+++ b/.github/workflows/create-slot-name.yml
@@ -22,14 +22,14 @@ jobs:
     steps:
       # Uses the provided branch name or it defaults to the current
       # branch, if empty, for the deployment slot name (legacy behaviour)
-      # Uses v6
+      # Uses v8
       - name: Get branch name
         if: ${{ inputs.branch-name == '' }}
         id: auto-branch-name
         uses: tj-actions/branch-names@v8
 
       # Remove forward slash from name as its invalid for deployment slot name.
-      # Uses v2      
+      # Uses v5
       - name: Remove '/' from branch name
         id: rename-branch-name
         uses: mad9000/actions-find-and-replace-string@5
@@ -49,7 +49,7 @@ jobs:
           webAppName: ${{ inputs.webApp }}
 
         # Truncate branch name so site name and slot name combined are fewer than 59 characters
-        # Uses v1.2.0
+        # Uses v1.4
       - name: Truncate branch name
         id: truncate-branch-name
         uses: 2428392/gh-truncate-string-action@v1.4

--- a/.github/workflows/deploy-to-deployment-slot.yml
+++ b/.github/workflows/deploy-to-deployment-slot.yml
@@ -36,11 +36,13 @@ on:
 
 jobs:
   create-slot-name:
+    name: Create Slot Name
     uses: ./.github/workflows/create-slot-name.yml
     with:
       webApp: ${{ inputs.webApp }}
 
   build:
+    name: Build Angular App
     uses: ./.github/workflows/build-angular.yml
     with:
       build-env: ${{ inputs.buildEnv }}
@@ -48,6 +50,7 @@ jobs:
       angular-cli-version: ${{ inputs.angular-cli-version }}
   #Only create slot once name identified
   create-slot:
+    name: Create Slot
     needs: [ create-slot-name ]
     uses: ./.github/workflows/create-slot.yml
     with:

--- a/.github/workflows/tag-main.yml
+++ b/.github/workflows/tag-main.yml
@@ -5,7 +5,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
       - name: Increase version and push tag


### PR DESCRIPTION
## Issue Type

<!-- ignore-task-list-start -->

- [X] 💡 Improvement

<!-- ignore-task-list-end -->

## Description

- Updates the versions of dependency to mitigate set-output becoming deprecated
- Adds a name to each of the steps for minor improvement to logs

## Screenshots

#### Before:
![chrome_npmj7AD1P8](https://github.com/user-attachments/assets/0a92541a-6f7f-46d1-ab11-cfa11f460153)

#### After:
![chrome_55Ocycye2Q](https://github.com/user-attachments/assets/e515e366-359c-482b-8f57-4a3e29ec8fbc)

## Checklist

- [X] I am merging into the correct branch
- [X] I have tested that my fix/feature works and meets the acceptance criteria

