### PR TITLE
GTP-1275 Workflow to clone firestore indexes

### DIFF
--- a/.github/workflows/clone-firestore-indexes.yml
+++ b/.github/workflows/clone-firestore-indexes.yml
@@ -9,7 +9,7 @@ on:
                 type: string
 
             target-project-id:
-                description: "The Firebase Project ID to which indexes are to be cloned"
+                description: "The Firebase Project ID for receiving copied indexes"
                 required: true
                 type: string
 

--- a/.github/workflows/clone-firestore-indexes.yml
+++ b/.github/workflows/clone-firestore-indexes.yml
@@ -1,4 +1,5 @@
 name: Clone Firestore Indexes
+
 on:
     workflow_call:
         inputs:
@@ -6,15 +7,18 @@ on:
                 description: "The Firebase Project ID whose indexes are to be cloned"
                 required: true
                 type: string
+
             target-project-id:
                 description: "The Firebase Project ID to which indexes are to be cloned"
                 required: true
                 type: string
+
             node-version:
+                description: "Node version"
                 required: false
                 type: string
-                description: "Node version"
                 default: "20.x"
+
         secrets:
             gcp-sa-key:
                 required: true
@@ -24,42 +28,45 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
-            - name: Use Node.js ${{ inputs.node-version }}
-              uses: actions/setup-node@v4
-              with:
-                node-version: ${{ inputs.node-version }}
-            - name: Fetch indexes from ${{ inputs.original-project-id }} and deploy them to ${{ inputs.target-project-id }}
-              run: |
-                    # Install dependencies
-                    sudo apt-get install -y jq
-                    echo "npm install -g firebase-tools"
-                    npm install -g firebase-tools
-            
-                    GCP_SA_KEY="${{ secrets.gcp-sa-key }}"
-                    mkdir -p sa-key
-                    # Decode the key if necessary and store it as a JSON file
-                    if [ -n "$GCP_SA_KEY" ]; then
-                        if echo "$GCP_SA_KEY" | jq empty 2>/dev/null; then
-                            echo "GCP SA Key is JSON. Storing it directly."
-                            echo "$GCP_SA_KEY" > sa-key/gcp_key.json
-                        else
-                            echo "GCP SA Key is Base64 encoded. Decoding and storing."
-                            echo "$GCP_SA_KEY" | base64 -d > sa-key/gcp_key.json
-                        fi
-                        # Set the environmental variable for firebase
-                        export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/sa-key/gcp_key.json"
-                        else
-                        echo "GCP_SA_KEY is empty. Exiting."
-                        exit 1
-                    fi
-            
-                    # Ensure firestore.indexes.json is removed before creating a new one
-                    rm -f firestore.indexes.json
+        - uses: actions/checkout@v4
+        - name: Use Node.js ${{ inputs.node-version }}
+          uses: actions/setup-node@v4
+          with:
+            node-version: ${{ inputs.node-version }}
 
-                    echo "firebase firestore:indexes --project ${{ inputs.original-project-id }} > firestore.indexes.json"
-                    firebase firestore:indexes --project ${{ inputs.original-project-id }} > firestore.indexes.json 
+        - name: Fetch indexes from ${{ inputs.original-project-id }} and deploy them to ${{ inputs.target-project-id }}
+          run: |
+            # Install dependencies
+            sudo apt-get install -y jq
+            echo "npm install -g firebase-tools"
+            npm install -g firebase-tools
 
-                    echo "firebase deploy --only firestore:indexes --project ${{ inputs.target-project-id }}"
-                    firebase deploy --only firestore:indexes --project ${{ inputs.target-project-id }} 
-                    rm -rf sa-key
+            GCP_SA_KEY="${{ secrets.gcp-sa-key }}"
+            mkdir -p sa-key
+
+            # Decode the key if necessary and store it as a JSON file
+            if [ -n "$GCP_SA_KEY" ]; then
+                if echo "$GCP_SA_KEY" | jq empty 2>/dev/null; then
+                    echo "GCP SA Key is JSON. Storing it directly."
+                    echo "$GCP_SA_KEY" > sa-key/gcp_key.json
+                else
+                    echo "GCP SA Key is Base64 encoded. Decoding and storing."
+                    echo "$GCP_SA_KEY" | base64 -d > sa-key/gcp_key.json
+                fi
+                
+                trap 'rm -rf sa-key' EXIT
+                # Set the environmental variable for Firebase
+                export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/sa-key/gcp_key.json"
+            else
+                echo "GCP_SA_KEY is empty. Exiting."
+                exit 1
+            fi
+
+            # Ensure firestore.indexes.json is removed before creating a new one
+            rm -f firestore.indexes.json
+
+            echo "firebase firestore:indexes --project ${{ inputs.original-project-id }} > firestore.indexes.json"
+            firebase firestore:indexes --project ${{ inputs.original-project-id }} > firestore.indexes.json
+
+            echo "firebase deploy --only firestore:indexes --project ${{ inputs.target-project-id }}"
+            firebase deploy --only firestore:indexes --project ${{ inputs.target-project-id }}

--- a/.github/workflows/clone-firestore-indexes.yml
+++ b/.github/workflows/clone-firestore-indexes.yml
@@ -1,0 +1,65 @@
+name: Clone Firestore Indexes
+on:
+    workflow_call:
+        inputs:
+            original-project-id:
+                description: "The Firebase Project ID whose indexes are to be cloned"
+                required: true
+                type: string
+            target-project-id:
+                description: "The Firebase Project ID to which indexes are to be cloned"
+                required: true
+                type: string
+            node-version:
+                required: false
+                type: string
+                description: "Node version"
+                default: "20.x"
+        secrets:
+            gcp-sa-key:
+                required: true
+
+jobs:
+    clone-indexes:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Use Node.js ${{ inputs.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                node-version: ${{ inputs.node-version }}
+            - name: Fetch indexes from ${{ inputs.original-project-id }} and deploy them to ${{ inputs.target-project-id }}
+              run: |
+                    # Install dependencies
+                    sudo apt-get install -y jq
+                    echo "npm install -g firebase-tools"
+                    npm install -g firebase-tools
+            
+                    GCP_SA_KEY="${{ secrets.gcp-sa-key }}"
+                    mkdir -p sa-key
+                    # Decode the key if necessary and store it as a JSON file
+                    if [ -n "$GCP_SA_KEY" ]; then
+                        if echo "$GCP_SA_KEY" | jq empty 2>/dev/null; then
+                            echo "GCP SA Key is JSON. Storing it directly."
+                            echo "$GCP_SA_KEY" > sa-key/gcp_key.json
+                        else
+                            echo "GCP SA Key is Base64 encoded. Decoding and storing."
+                            echo "$GCP_SA_KEY" | base64 -d > sa-key/gcp_key.json
+                        fi
+                        # Set the environmental variable for firebase
+                        export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/sa-key/gcp_key.json"
+                        else
+                        echo "GCP_SA_KEY is empty. Exiting."
+                        exit 1
+                    fi
+            
+                    # Ensure firestore.indexes.json is removed before creating a new one
+                    rm -f firestore.indexes.json
+
+                    echo "firebase firestore:indexes --project ${{ inputs.original-project-id }} > firestore.indexes.json"
+                    firebase firestore:indexes --project ${{ inputs.original-project-id }} > firestore.indexes.json 
+
+                    echo "firebase deploy --only firestore:indexes --project ${{ inputs.target-project-id }}"
+                    firebase deploy --only firestore:indexes --project ${{ inputs.target-project-id }} 
+                    rm -rf sa-key


### PR DESCRIPTION
## Issue Type

<!-- ignore-task-list-start -->

- [ ] 🪲 Fix
- [ ] 💡 Improvement
- [X] 🏁 Feature
- [ ] 🍾 Release
<!-- ignore-task-list-end -->

## Description

- Takes the GCP Service Account Key as Authentication and fetches the indexes from one project and deploys them to another. 


## Screenshots

![chrome_leO6Hz2nyQ](https://github.com/user-attachments/assets/cb402d8b-ea91-486d-969e-f213f8596476)

## Checklist

- [X] I am merging into the correct branch
- [X] I have tested that my fix/feature works and meets the acceptance criteria

## Notes
- Must ensure that the service account being used has permissions to **read** indexes from the initial project, and **deploy** indexes to the target project. 
